### PR TITLE
CI: Add --warning-mode=fail to Gradle build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 6 * * 1' # Monday at 06 UTC
 
 jobs:
   build-and-test:
@@ -44,6 +46,9 @@ jobs:
       - name: Write key store
         run: echo $KEYSTORE_FILE | base64 --decode > keystore.jks
       - name: Build & test
+        run: ./gradlew testDebug testTstDebug lint assemTstRelease assemAccRelease assemProdRelease bundleProdRelease
+      - name: Build & test scheduled
+        if: (github.event_name == 'schedule')
         run: ./gradlew --warning-mode=fail testDebug testTstDebug lint assemTstRelease assemAccRelease assemProdRelease bundleProdRelease
       - name: Clean up key store
         if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Write key store
         run: echo $KEYSTORE_FILE | base64 --decode > keystore.jks
       - name: Build & test
-        run: ./gradlew testDebug testTstDebug lint assemTstRelease assemAccRelease assemProdRelease bundleProdRelease
+        run: ./gradlew --warning-mode=fail testDebug testTstDebug lint assemTstRelease assemAccRelease assemProdRelease bundleProdRelease
       - name: Clean up key store
         if: ${{ always() }}
         run: rm keystore.jks


### PR DESCRIPTION
Added `--warning-mode=fail` to the Gradle build to let the CI fail if any warnings are thrown.