### PR TITLE
Add Dependabot configuration to check for dependencies updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "06:00"
+    timezone: Europe/Berlin
+
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "06:00"
+    timezone: Europe/Berlin


### PR DESCRIPTION
Adds a Dependabot configuration which checks daily if new Gradle or GitHub Actions dependencies are available. If so, it opens a PR with that Dependency update.

See [Configuration options for dependency updates](https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates) for more about the exact configuration.