### PR TITLE
Fix link to the coronacheck iOS app

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This repository contains the Android prototype of the Dutch COVID-19 CoronaCheck project.
 
 * The Android app is located in the repository you are currently viewing.
-* The iOS app can be found here: https://github.com/minvws/nl-covid-19-coronacheck-app-ios 
+* The iOS app can be found here: https://github.com/minvws/nl-covid19-coronacheck-app-ios
 
 The project is currently an experimental prototype to explore technical possibilities.   
 


### PR DESCRIPTION
This fixes the iOS repository URL which currently resolves in a 404 Not Found. The repository URL is https://github.com/minvws/nl-covid19-coronacheck-app-ios, not https://github.com/minvws/nl-covid-19-coronacheck-app-ios (extra hyphen).

> If you have a trivial fix or improvement, go ahead and create a pull request, addressing (with @...) a suitable maintainer of this repository in the description of the pull request.

@ijansch want to check this out? Git blame indicated you ;)