### PR TITLE
Fix an accessibility issue with some 'Something wrong' dialogs

### DIFF
--- a/holder/src/main/res/values-en/strings.xml
+++ b/holder/src/main/res/values-en/strings.xml
@@ -213,7 +213,7 @@
     <string name="travel_fragment_footer">The Dutch QR code only contains your initials, your birth month, and your day of birth.</string>
     <string name="travel_fragment_footer_eu">The international QR code contains the following details: your name, date of birth, and information about the vaccine.</string>
     <string name="dialog_negative_test_result_something_wrong_title">Something is wrong</string>
-    <string name="dialog_negative_test_result_something_wrong_description">Is your name or date of birth wrong? Look <a href="https://coronacheck.nl/en/guidepost">here</a> for more information.</string>
+    <string name="dialog_negative_test_result_something_wrong_description"><![CDATA[Is your name or date of birth wrong? Look <a href="https://coronacheck.nl/en/guidepost">here</a> for more information.]]></string>
     <string name="validity_type_european_title">International</string>
     <string name="validity_type_dutch_title">the Netherlands</string>
     <string name="qr_explanation_title_domestic">About my Dutch QR code</string>

--- a/holder/src/main/res/values/strings.xml
+++ b/holder/src/main/res/values/strings.xml
@@ -278,6 +278,6 @@
     <string name="coronacheck_error_description">Neem contact op met onze helpdesk en geef de foutcode (%1$s) door. Of probeer het later opnieuw.</string>
     <string name="missing_events_title">Gegevens mogelijk niet compleet</string>
     <string name="missing_events_description">Door drukte of een storing bij een van de partijen kunnen er gegevens missen. Probeer het eventueel later nog een keer.</string>
-    <string name="dialog_vaccination_something_wrong_description"><![CDATA[Kloppen je naam en/of geboortedatum niet? Of staat er onjuiste informatie over je vaccinatie? Kijk hier voor meer informatie.]]></string>
+    <string name="dialog_vaccination_something_wrong_description"><![CDATA[Kloppen je naam en/of geboortedatum niet? Of staat er onjuiste informatie over je vaccinatie? Kijk <a href="https://coronacheck.nl/wegwijzer">hier</a> voor meer informatie.]]></string>
     <string name="commercial_test_unique_code_hint_screenreader">Vul hier je ophaalcode in</string>
 </resources>

--- a/holder/src/main/res/values/strings.xml
+++ b/holder/src/main/res/values/strings.xml
@@ -213,7 +213,7 @@
     <string name="travel_fragment_footer">In je Nederlandse QR-code staan alleen je initialen en je geboortedag en maand.</string>
     <string name="travel_fragment_footer_eu">In de internationale QR-code staan de volgende gegevens: o.a. je naam, geboortedatum en informatie over het vaccin.</string>
     <string name="dialog_negative_test_result_something_wrong_title">Er klopt iets niet</string>
-    <string name="dialog_negative_test_result_something_wrong_description">Kloppen je naam en/of geboortedatum niet? Kijk <a href="https://coronacheck.nl/wegwijzer">hier</a> voor meer informatie.</string>
+    <string name="dialog_negative_test_result_something_wrong_description"><![CDATA[Kloppen je naam en/of geboortedatum niet? Kijk <a href="https://coronacheck.nl/wegwijzer">hier</a> voor meer informatie.]]></string>
     <string name="validity_type_european_title">Internationaal</string>
     <string name="validity_type_dutch_title">Nederland</string>
     <string name="qr_explanation_title_domestic">Over mijn Nederlandse QR-code</string>


### PR DESCRIPTION
### Describe the bug, issue or concern

In some dialogs where you can click 'Something wrong' it showed text that wasn't clickable. In one place the text also didn't specify that is contained CDATA.

### Governance
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md