### PR TITLE
Fix "Disease targeted:" text value in international QR info screen (#54)

### DIFF
--- a/holder/src/main/java/nl/rijksoverheid/ctr/holder/ui/create_qr/util/InfoScreenUtil.kt
+++ b/holder/src/main/java/nl/rijksoverheid/ctr/holder/ui/create_qr/util/InfoScreenUtil.kt
@@ -243,7 +243,7 @@ class InfoScreenUtilImpl(
             }
         } ?: ""
 
-        val disease = application.getString(R.string.your_vaccination_explanation_covid_19)
+        val disease = application.getString(R.string.your_vaccination_explanation_covid_19_answer)
 
         val testType = holderConfig.euTestTypes.firstOrNull {
             it.code == test.getStringOrNull("tt")
@@ -354,7 +354,7 @@ class InfoScreenUtilImpl(
             }
         } ?: ""
 
-        val disease = application.getString(R.string.your_vaccination_explanation_covid_19)
+        val disease = application.getString(R.string.your_vaccination_explanation_covid_19_answer)
 
         val vaccin = holderConfig.euBrands.firstOrNull {
             it.code == vaccination.getStringOrNull("mp")
@@ -443,7 +443,7 @@ class InfoScreenUtilImpl(
             }
         } ?: ""
 
-        val disease = application.getString(R.string.your_vaccination_explanation_covid_19)
+        val disease = application.getString(R.string.your_vaccination_explanation_covid_19_answer)
 
         val testDate = recovery.getStringOrNull("fr")?.let { testDate ->
             try {


### PR DESCRIPTION
This PR creates the expected behaviour described in issue #54 (it seems like the wrong string ID was used).