### PR TITLE
Adjust the time used for domestic QR code generation with clock skew

### DIFF
--- a/appconfig/src/main/java/nl/rijksoverheid/ctr/appconfig/usecases/ClockDeviationUseCase.kt
+++ b/appconfig/src/main/java/nl/rijksoverheid/ctr/appconfig/usecases/ClockDeviationUseCase.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import nl.rijksoverheid.ctr.shared.livedata.Event
 import java.time.Clock
+import java.time.Duration
 import kotlin.math.abs
 
 abstract class ClockDeviationUseCase {
@@ -20,6 +21,7 @@ abstract class ClockDeviationUseCase {
 
     abstract fun store(serverResponseTimestamp: Long, localReceivedTimestamp: Long)
     abstract fun hasDeviation(): Boolean
+    abstract fun getAdjustedClock(clock: Clock): Clock
 }
 
 const val SECOND_IN_MS = 1000
@@ -55,5 +57,12 @@ class ClockDeviationUseCaseImpl(
             cachedAppConfigUseCase.getCachedAppConfig().clockDeviationThresholdSeconds
 
         return (abs(systemUptimeDelta + responseTimeDelta) / SECOND_IN_MS) >= thresholdInSeconds
+    }
+
+    override fun getAdjustedClock(clock: Clock): Clock {
+        return Clock.offset(
+            clock,
+            Duration.ofMillis(localServerResponseTimeStamp - localResponseReceivedTimeStamp)
+        )
     }
 }

--- a/holder/src/main/java/nl/rijksoverheid/ctr/holder/modules/EventsUseCasesModule.kt
+++ b/holder/src/main/java/nl/rijksoverheid/ctr/holder/modules/EventsUseCasesModule.kt
@@ -1,5 +1,6 @@
 package nl.rijksoverheid.ctr.holder.modules
 
+import nl.rijksoverheid.ctr.appconfig.usecases.ClockDeviationUseCase
 import nl.rijksoverheid.ctr.holder.persistence.database.usecases.RemoveExpiredEventsUseCase
 import nl.rijksoverheid.ctr.holder.persistence.database.usecases.RemoveExpiredEventsUseCaseImpl
 import nl.rijksoverheid.ctr.holder.ui.create_qr.usecases.*
@@ -25,10 +26,12 @@ val eventsUseCasesModule = module {
         GetRemoteEventsUseCaseImpl(get())
     }
     factory<QrCodeUseCase> {
+        val clockDeviationUseCase = get<ClockDeviationUseCase>()
         QrCodeUseCaseImpl(
             get(),
             get(),
-            get()
+            get(),
+            clockDeviationUseCase.getAdjustedClock(Clock.systemDefaultZone())
         )
     }
     factory<GetEventsUseCase> { GetEventsUseCaseImpl(get(), get(), get(), get(), get(), get()) }

--- a/holder/src/main/java/nl/rijksoverheid/ctr/holder/ui/create_qr/usecases/QrCodeUseCase.kt
+++ b/holder/src/main/java/nl/rijksoverheid/ctr/holder/ui/create_qr/usecases/QrCodeUseCase.kt
@@ -8,6 +8,7 @@ import nl.rijksoverheid.ctr.holder.persistence.PersistenceManager
 import nl.rijksoverheid.ctr.holder.persistence.database.entities.GreenCardType
 import nl.rijksoverheid.ctr.holder.ui.myoverview.utils.QrCodeUtil
 import nl.rijksoverheid.ctr.shared.MobileCoreWrapper
+import java.time.Clock
 
 /*
  *  Copyright (c) 2021 De Staat der Nederlanden, Ministerie van Volksgezondheid, Welzijn en Sport.
@@ -24,6 +25,7 @@ class QrCodeUseCaseImpl(
     private val persistenceManager: PersistenceManager,
     private val qrCodeUtil: QrCodeUtil,
     private val mobileCoreWrapper: MobileCoreWrapper,
+    private val clock: Clock
 ) : QrCodeUseCase {
 
     override suspend fun qrCode(
@@ -39,7 +41,8 @@ class QrCodeUseCaseImpl(
 
             val qrCodeContent = if (shouldDisclose) mobileCoreWrapper.disclose(
                 secretKey.toByteArray(),
-                credential
+                credential,
+                clock.millis()
             ) else String(credential)
 
             qrCodeUtil.createQrCode(

--- a/holder/src/test/java/nl/rijksoverheid/ctr/holder/Fakes.kt
+++ b/holder/src/test/java/nl/rijksoverheid/ctr/holder/Fakes.kt
@@ -34,6 +34,7 @@ import nl.rijksoverheid.ctr.shared.models.*
 import nl.rijksoverheid.ctr.shared.utils.PersonalDetailsUtil
 import nl.rijksoverheid.ctr.shared.utils.TestResultUtil
 import org.json.JSONObject
+import java.time.Clock
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
@@ -458,7 +459,7 @@ fun fakeMobileCoreWrapper(): MobileCoreWrapper {
             return ""
         }
 
-        override fun disclose(secretKey: ByteArray, credential: ByteArray): String {
+        override fun disclose(secretKey: ByteArray, credential: ByteArray, currentTimeMillis: Long): String {
             return ""
         }
 
@@ -626,6 +627,8 @@ fun fakeClockDevationUseCase(
     override fun hasDeviation(): Boolean {
         return hasDeviation
     }
+
+    override fun getAdjustedClock(clock: Clock): Clock = Clock.systemDefaultZone()
 }
 
 fun fakeReadEuropeanCredentialUtil(dosis: String = "") = object: ReadEuropeanCredentialUtil {

--- a/holder/src/test/java/nl/rijksoverheid/ctr/holder/ui/create_qr/usecases/GetDashboardItemsUseCaseImplTest.kt
+++ b/holder/src/test/java/nl/rijksoverheid/ctr/holder/ui/create_qr/usecases/GetDashboardItemsUseCaseImplTest.kt
@@ -18,6 +18,7 @@ import org.koin.dsl.module
 import org.koin.test.AutoCloseKoinTest
 import org.koin.test.inject
 import org.robolectric.RobolectricTestRunner
+import java.time.Clock
 import java.time.OffsetDateTime
 
 @RunWith(RobolectricTestRunner::class)
@@ -349,6 +350,8 @@ class GetDashboardItemsUseCaseImplTest: AutoCloseKoinTest() {
                 override fun hasDeviation(): Boolean {
                     return hasDeviation
                 }
+
+                override fun getAdjustedClock(clock: Clock): Clock = Clock.systemDefaultZone()
             }
         }
     }

--- a/shared/src/main/java/nl/rijksoverheid/ctr/shared/MobileCoreWrapper.kt
+++ b/shared/src/main/java/nl/rijksoverheid/ctr/shared/MobileCoreWrapper.kt
@@ -29,7 +29,7 @@ interface MobileCoreWrapper {
     fun readDomesticCredential(credential: ByteArray): ReadDomesticCredential
     fun readCredential(credentials: ByteArray): ByteArray
     fun createCommitmentMessage(secretKey: ByteArray, prepareIssueMessage: ByteArray): String
-    fun disclose(secretKey: ByteArray, credential: ByteArray): String
+    fun disclose(secretKey: ByteArray, credential: ByteArray, currentTimeMillis: Long): String
     fun generateHolderSk(): String
     fun createDomesticCredentials(createCredentials: ByteArray): List<DomesticCredential>
     fun readEuropeanCredential(credential: ByteArray): JSONObject
@@ -73,10 +73,11 @@ class MobileCoreWrapperImpl(private val moshi: Moshi) : MobileCoreWrapper {
         return String(result.value)
     }
 
-    override fun disclose(secretKey: ByteArray, credential: ByteArray): String {
+    override fun disclose(secretKey: ByteArray, credential: ByteArray, currentTimeMillis: Long): String {
         return Mobilecore.disclose(
             secretKey,
-            credential
+            credential,
+            currentTimeMillis / 1000L
         ).successString()
     }
 

--- a/verifier/src/test/java/nl/rijksoverheid/ctr/verifier/Fakes.kt
+++ b/verifier/src/test/java/nl/rijksoverheid/ctr/verifier/Fakes.kt
@@ -174,7 +174,7 @@ fun fakeMobileCoreWrapper(): MobileCoreWrapper {
             return ""
         }
 
-        override fun disclose(secretKey: ByteArray, credential: ByteArray): String {
+        override fun disclose(secretKey: ByteArray, credential: ByteArray, currentTimeMillis: Long): String {
             return ""
         }
 


### PR DESCRIPTION
For various reasons the device clock might be set incorrectly, whilst verification of the QR code by the scanner app requires an accurate timestamp for the challenge. To make generation of the code more resilient, the server time is used to adjust the timestamp used for generation to the "actual" timestamp.

As this timestamp is determined when the app configuration is retrieved only and not persisted, the adjustment currently requires a the app to be online when the app config is checked. This is probably OK for the common case in NL where most phones will be online.

During testing I noticed that the determined clock difference is larger than it actually is (around ~4 sec on my device). This might be caused by processing the response that seems to take quite some time, but in practice that extra offset doesn't affect this functionality, as long as it's under the threshold of maximum configured time skew.

This PR depends on changes to the `nl-covid19-coronacheck-mobile-core`; as this project uses a binary (unversioned) blob of that library from a private repository the version included with this PR most likely must be updated after merging both change to mobile core (https://github.com/minvws/nl-covid19-coronacheck-mobile-core/pull/4) and this PR.

This fixes #67 though the message has not been removed or disabled; it is probably still useful for cases where the clock skew is not automatically corrected and to alert a user that the device time in general might be incorrect.