### PR TITLE
Show correct total number of doses on the International QR selector

### DIFF
--- a/holder/src/main/java/nl/rijksoverheid/ctr/holder/ui/myoverview/QrCodesFragment.kt
+++ b/holder/src/main/java/nl/rijksoverheid/ctr/holder/ui/myoverview/QrCodesFragment.kt
@@ -241,7 +241,7 @@ class QrCodesFragment : Fragment(R.layout.fragment_qr_codes) {
         binding.qrVaccinationDosis.visibility = View.VISIBLE
         binding.qrVaccinationDosis.text = getString(
             R.string.qr_code_dosis,
-            "${europeanVaccinations.first().dose}/${europeanVaccinations.first().ofTotalDoses}"
+            "${europeanVaccinations.first().dose}/${europeanVaccinations.size}"
         )
 
         // If there are more then one vaccinations we update UI based on the selected page
@@ -289,7 +289,7 @@ class QrCodesFragment : Fragment(R.layout.fragment_qr_codes) {
             val vaccination = europeanVaccinations[position]
             binding.qrVaccinationDosis.text = getString(
                 R.string.qr_code_dosis,
-                "${vaccination.dose}/${vaccination.ofTotalDoses}"
+                "${vaccination.dose}/${europeanVaccinations.size}"
             )
 
             showDoseInfo(vaccination)


### PR DESCRIPTION
See issue #78: Total number of doses is not shown correctly in international vaccination after booster (3rd) vaccination

This commit should show the correct number of total doses in the selector on the International QR Code viewer.

